### PR TITLE
Add balloon and entropy devices

### DIFF
--- a/RosettaVM/AppDelegate.swift
+++ b/RosettaVM/AppDelegate.swift
@@ -193,7 +193,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, VZVirtualMachineDelegate {
     private func createGraphicsDeviceConfiguration() -> VZVirtioGraphicsDeviceConfiguration {
         let graphicsDevice = VZVirtioGraphicsDeviceConfiguration()
         graphicsDevice.scanouts = [
-            VZVirtioGraphicsScanoutConfiguration(widthInPixels: 1280, heightInPixels: 720)
+            VZVirtioGraphicsScanoutConfiguration(widthInPixels: 1920, heightInPixels: 1080)
         ]
 
         return graphicsDevice


### PR DESCRIPTION
- Ensure that macOS can reclaim unused memory from the running VM by adding a memoryBalloon device
- Improve encryption speed within the VM by adding an entropy device
