### PR TITLE
Add balloon and entropy devices

### DIFF
--- a/RosettaVM/AppDelegate.swift
+++ b/RosettaVM/AppDelegate.swift
@@ -265,6 +265,9 @@ class AppDelegate: NSObject, NSApplicationDelegate, VZVirtualMachineDelegate {
         }
         virtualMachineConfiguration.storageDevices = disks
 
+        virtualMachineConfiguration.memoryBalloonDevices = [VZVirtioTraditionalMemoryBalloonDeviceConfiguration()]
+        virtualMachineConfiguration.entropyDevices = [VZVirtioEntropyDeviceConfiguration()]
+
         virtualMachineConfiguration.networkDevices = [try createNetworkDeviceConfiguration()]
         virtualMachineConfiguration.graphicsDevices = [createGraphicsDeviceConfiguration()]
         virtualMachineConfiguration.audioDevices = [createInputAudioDeviceConfiguration(), createOutputAudioDeviceConfiguration()]


### PR DESCRIPTION
- Ensure that macOS can reclaim unused memory from the running VM by adding a memoryBalloon device
- Improve encryption speed within the VM by adding an entropy device
